### PR TITLE
Define foreign keys in schema and handle discontinued products

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -6,11 +6,11 @@ CREATE SCHEMA public;
 CREATE TABLE product (
     asin VARCHAR(20) PRIMARY KEY,
     title TEXT NOT NULL,
-    group_name TEXT NOT NULL,      -- grupo principal do produto (ex: Book, DVD)
-    salesrank INTEGER NOT NULL,
-    total_reviews INTEGER NOT NULL,
-    downloaded INTEGER NOT NULL,
-    avg_rating FLOAT NOT NULL
+    group_name TEXT,               -- grupo principal do produto (ex: Book, DVD)
+    salesrank INTEGER,
+    total_reviews INTEGER,
+    downloaded INTEGER,
+    avg_rating FLOAT
 );
 
 -- Tabela Customer: clientes identificados por ID
@@ -23,7 +23,11 @@ CREATE TABLE customer (
 CREATE TABLE category (
     category_id INTEGER PRIMARY KEY,              -- usando IDs fornecidos no dataset
     category_name TEXT NOT NULL,
-    parent_id INTEGER
+    parent_id INTEGER,
+    CONSTRAINT fk_category_parent
+        FOREIGN KEY (parent_id)
+        REFERENCES category (category_id)
+        DEFERRABLE INITIALLY DEFERRED
 );
 
 -- Tabela Review: avaliações de produtos pelos clientes
@@ -35,6 +39,14 @@ CREATE TABLE review (
     votes INTEGER NOT NULL,
     asin VARCHAR(20) NOT NULL,
     customer_id VARCHAR(20) NOT NULL,
+    CONSTRAINT fk_review_product
+        FOREIGN KEY (asin)
+        REFERENCES product (asin)
+        DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT fk_review_customer
+        FOREIGN KEY (customer_id)
+        REFERENCES customer (customer_id)
+        DEFERRABLE INITIALLY DEFERRED,
     UNIQUE (asin, customer_id, review_date)
 );
 
@@ -42,7 +54,15 @@ CREATE TABLE review (
 CREATE TABLE product_category (
     asin VARCHAR(10) NOT NULL,
     category_id INTEGER NOT NULL,
-    PRIMARY KEY (asin, category_id)
+    PRIMARY KEY (asin, category_id),
+    CONSTRAINT fk_product_category_product
+        FOREIGN KEY (asin)
+        REFERENCES product (asin)
+        DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT fk_product_category_category
+        FOREIGN KEY (category_id)
+        REFERENCES category (category_id)
+        DEFERRABLE INITIALLY DEFERRED
 );
 
 -- Tabela Product_Similar: relação N:N de "produtos similares" (co-compra)
@@ -50,5 +70,16 @@ CREATE TABLE product_category (
 CREATE TABLE product_similar (
     asin VARCHAR(20) NOT NULL,
     similar_asin VARCHAR(20) NOT NULL,
-    PRIMARY KEY (asin, similar_asin)
+    PRIMARY KEY (asin, similar_asin),
+    CONSTRAINT fk_product_similar_product
+        FOREIGN KEY (asin)
+        REFERENCES product (asin)
+        DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT fk_product_similar_similar
+        FOREIGN KEY (similar_asin)
+        REFERENCES product (asin)
+        DEFERRABLE INITIALLY DEFERRED
 );
+
+CREATE INDEX idx_review_asin ON review (asin);
+CREATE INDEX idx_product_category_cat ON product_category (category_id);


### PR DESCRIPTION
## Summary
- Define all foreign-key constraints and supporting indexes directly in `schema.sql` while allowing nullable product metrics for discontinued items
- Update the ETL pipeline to respect immediate constraint enforcement by flushing dependent tables first and tracking pending similar-product relationships
- Preserve discontinued product records with `NULL` values for missing metrics and ensure post-load cleanup only runs `ANALYZE`

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d5ea87ab688323a104fba348959b85